### PR TITLE
Fixing the tmp_file write fail #10

### DIFF
--- a/code/machine_learning/crf.py
+++ b/code/machine_learning/crf.py
@@ -178,7 +178,8 @@ def predict(clf, X):
     # Dump the model into a temp file
     os_handle,tmp_file = tempfile.mkstemp(dir=tmp_dir, suffix="crf_temp")
     with open(tmp_file, 'wb') as f:
-        f.write(clf)
+        clf_byte = bytearray(clf, 'latin1')
+        f.write(clf_byte)
 
     # Create the Tagger object
     tagger = pycrfsuite.Tagger()


### PR DESCRIPTION
**Reference Issues/PRs**
This addresses #10. This goal of this PR is to fix the encoding of the "clf" variable to enable the write to tmp_file and solve #10 😎 

**What does this implement/fix? Explain your changes.**
Using the inbuilt _bytearray_ method to fix the encoding issue while writing to the temporary file. See variable "clf_byte" 🔥 

**Any other comments?**
This is my first PR to CliNER. I faced the issue and debugged it on my end. Let me know if the fix is satisfactory! 😅@wboag